### PR TITLE
Fix Wifi AP

### DIFF
--- a/firmware/lib/cw-commons/WiFiController.h
+++ b/firmware/lib/cw-commons/WiFiController.h
@@ -15,10 +15,10 @@ struct WiFiController
   static void onImprovWiFiErrorCb(ImprovTypes::Error err)
   {
     ClockwiseWebServer::getInstance()->stopWebServer();
-    StatusController::getInstance()->blink_led(2000, 3); 
+    StatusController::getInstance()->blink_led(2000, 3);
   }
 
-  static void onImprovWiFiConnectedCb(const char* ssid, const char* password)
+  static void onImprovWiFiConnectedCb(const char *ssid, const char *password)
   {
     ClockwiseParams::getInstance()->load();
     ClockwiseParams::getInstance()->wifiSsid = String(ssid);
@@ -28,7 +28,8 @@ struct WiFiController
     ClockwiseWebServer::getInstance()->startWebServer();
   }
 
-  static bool isConnected() {
+  static bool isConnected()
+  {
     return improvSerial.isConnected();
   }
 
@@ -37,7 +38,7 @@ struct WiFiController
     improvSerial.handleSerial();
   }
 
-    void saveWiFiCredentials()
+  void saveWiFiCredentials()
   {
     ClockwiseParams::getInstance()->wifiSsid = String(WiFi.SSID());
     ClockwiseParams::getInstance()->wifiPwd = String(WiFi.psk());
@@ -55,7 +56,8 @@ struct WiFiController
 
     ClockwiseParams::getInstance()->load();
 
-    if (!ClockwiseParams::getInstance()->wifiSsid.isEmpty()) {
+    if (!ClockwiseParams::getInstance()->wifiSsid.isEmpty())
+    {
       if (improvSerial.tryConnectToWifi(ClockwiseParams::getInstance()->wifiSsid.c_str(), ClockwiseParams::getInstance()->wifiPwd.c_str()))
       {
         connectionSucessfulOnce = true;
@@ -63,17 +65,14 @@ struct WiFiController
         return true;
       }
     }
-     else
-    {
-      WiFiManager wifiManager;
-      wifiManager.startConfigPortal("Clockwise");
-      if (WiFi.status() == WL_CONNECTED)
-      {
-        saveWiFiCredentials();
-      }
-    }
 
     StatusController::getInstance()->wifiConnectionFailed();
+    WiFiManager wifiManager;
+    wifiManager.startConfigPortal("Clockwise");
+    if (WiFi.status() == WL_CONNECTED)
+    {
+      saveWiFiCredentials();
+    }
     return false;
   }
 };

--- a/firmware/lib/cw-commons/WiFiController.h
+++ b/firmware/lib/cw-commons/WiFiController.h
@@ -67,11 +67,15 @@ struct WiFiController
     }
 
     StatusController::getInstance()->wifiConnectionFailed();
-    WiFiManager wifiManager;
-    wifiManager.startConfigPortal("Clockwise");
-    if (WiFi.status() == WL_CONNECTED)
+
+    if (WiFi.status() != WL_CONNECTED)
     {
-      saveWiFiCredentials();
+      WiFiManager wifiManager;
+      wifiManager.startConfigPortal("Clockwise");
+      if (WiFi.status() == WL_CONNECTED)
+      {
+        saveWiFiCredentials();
+      }
     }
     return false;
   }

--- a/firmware/lib/cw-commons/WiFiController.h
+++ b/firmware/lib/cw-commons/WiFiController.h
@@ -4,6 +4,7 @@
 #include <WiFi.h>
 #include "CWWebServer.h"
 #include "StatusController.h"
+#include <WiFiManager.h>
 
 ImprovWiFi improvSerial(&Serial);
 
@@ -36,6 +37,13 @@ struct WiFiController
     improvSerial.handleSerial();
   }
 
+    void saveWiFiCredentials()
+  {
+    ClockwiseParams::getInstance()->wifiSsid = String(WiFi.SSID());
+    ClockwiseParams::getInstance()->wifiPwd = String(WiFi.psk());
+    ClockwiseParams::getInstance()->save();
+  }
+
   bool begin()
   {
     WiFi.mode(WIFI_STA);
@@ -53,6 +61,15 @@ struct WiFiController
         connectionSucessfulOnce = true;
         ClockwiseWebServer::getInstance()->startWebServer();
         return true;
+      }
+    }
+     else
+    {
+      WiFiManager wifiManager;
+      wifiManager.startConfigPortal("Clockwise");
+      if (WiFi.status() == WL_CONNECTED)
+      {
+        saveWiFiCredentials();
       }
     }
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -27,4 +27,5 @@ lib_deps =
 	https://github.com/PaulStoffregen/Time.git
 	ropg/ezTime@^0.8.3
 	https://github.com/jnthas/Improv-WiFi-Library
+	https://github.com/tzapu/WiFiManager
 src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<clockfaces/>


### PR DESCRIPTION
This returns the functionality of allowing the user to setup wifi without a computer.

Improv is a great library and has a lot of things going for it, but sadly it sometimes doesn't allow the user to setup wifi after flashing the device. 

![image](https://user-images.githubusercontent.com/13477955/236510528-2878713b-4412-46a1-b2db-f0810f97e64f.png)

# After clicking Next
![image](https://user-images.githubusercontent.com/13477955/236510577-00df9ce0-e3c8-4068-93b7-a0e5b53de050.png)
# No Option to setup wifi 😅 


In that case, the user is unable to setup wifi, without a computer. 

This fixes that by using the tried and true `WifiManager` to setup an AP Portal under the wifi name `Clockwise` 

This opens up a portal allowing the user to input their credentials 

which is then saved 
by 
```
ClockwiseParams::getInstance()->wifiSsid = String(WiFi.SSID());
ClockwiseParams::getInstance()->wifiPwd = String(WiFi.psk());
ClockwiseParams::getInstance()->save();
```

Ran it locally and worked like a charm 

![image](https://user-images.githubusercontent.com/13477955/236505737-f0123bda-23bb-498f-9475-37b1ce54f2bc.png)
