### PR TITLE
(esp-idf) Add build definitions for `CW_FW_VERSION` and `CW_FW_NAME`.

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,3 +5,5 @@ idf_component_register(
 			INCLUDE_DIRS ${PROJECT_DIR}/firmware/src
 			REQUIRES ESP32-HUB75-MatrixPanel-I2S-DMA cw-commons cw-gfx-engine WiFiManager ${CLOCKFACES}
                        )
+
+target_compile_options(${COMPONENT_TARGET} PUBLIC -DCW_FW_VERSION="1.2.2" -DCW_FW_NAME="Clockwise")


### PR DESCRIPTION
The project fails to compile on ESP-IDF because these definitions are missing.

I'm trying to fix https://github.com/jnthas/clockwise/issues/16 and this error is preventing the project from compiling.