### PR TITLE
Change `REQUIRES` -> `PRIV_REQUIRES`. Add dependency on `Adafruit-GFX…

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CLOCKFACES cw-cf-0x01 cw-cf-0x02 cw-cf-0x03 cw-cf-0x04 cw-cf-0x05 cw-cf-0x06
 idf_component_register(
 			SRC_DIRS "."
 			INCLUDE_DIRS ${PROJECT_DIR}/firmware/src
-			REQUIRES ESP32-HUB75-MatrixPanel-I2S-DMA cw-commons cw-gfx-engine WiFiManager Improv-WiFi-Library arduino ${CLOCKFACES}
+			PRIV_REQUIRES ESP32-HUB75-MatrixPanel-I2S-DMA cw-commons cw-gfx-engine WiFiManager Improv-WiFi-Library arduino Adafruit-GFX-Library ${CLOCKFACES}
                        )
 
 target_compile_options(${COMPONENT_TARGET} PUBLIC -DCW_FW_VERSION="1.2.2" -DCW_FW_NAME="Clockwise")


### PR DESCRIPTION
…-Library`

* Change `REQUIRES` to `PRIV_REQUIRES` for faster compile times (https://cmake.org/pipermail/cmake/2016-May/063400.html)
* Add `Adafruit-GFX-Library` as a direct requirement because it's used in `lib/cw-gfx-engine/Locator.h`