### PR TITLE
Add api documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# remove generated site
+/_site

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <header class="page-header" role="banner">
 
       <h1 class="project-name">
-        <img src="static/images/clockwise_logo_not1.png" alt="Clockwise" width="50%">
+        <img src="/static/images/clockwise_logo_not1.png" alt="Clockwise" width="50%">
       </h1>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,63 @@
+# Clockwise API
+
+Clockwise comes with a small built in server that provides a few calls to control your device. 
+
+We're documenting these here for easy referencing and access, but you can also use our [openapi.yml](/docs/openapi.yml) file with your OpenAPI tools of choice.
+
+For all requests (except "GET /") you will receive the HTTP status code 204 - No Content when the call was successfull.
+
+## GET /
+
+This call returns the HTML for the settings page of your Clockwise device.
+
+## GET /get
+
+Returns all clockwise related information about the device as "X-"-headers:
+- `X-displayBright`: Display brightness
+- `X-autoBrightMin`: Auto brightness minimum
+- `X-autoBrightMax`: Auto brightness maximum
+- `X-swapBlueGreen`: Is RBG used instead of RGB (blue & green are switched)?
+- `X-use24hFormat`: Use the 24h format instead of 12h for the clock
+- `X-ldrPin`: Which GPIO pin is currently defined for the LDR
+- `X-timeZone`: Currently selected time zone
+- `X-wifiSsid`: SSID the device is connected to
+- `X-ntpServer`: URL of the NTP server the device is connected to
+- `X-canvasFile`: Name of the canvas file that is currently being used
+- `X-canvasServer`: Address of the canvas server that is currently being used
+- `X-CW_FW_VERSION`: Clockwise firmware version
+- `X-CW_FW_NAME`: Clockwise firmware name
+- `X-CLOCKFACE_NAME`: Clockface name (e.g. `cw-cf-0x01`)
+
+## GET /read
+
+Getting pin information
+
+## POST /restart
+
+Can be used to restart the device.
+
+## POST /set
+
+You can set specific attributes of the device by using the following query parameters:
+
+- `displayBright`: Change display brightness
+- `wifiSsid`:  Wifi SSID to be used
+- `wifiPwd`: Wifi password to be used
+- `autoBright`: Set min and max values for autoBrightness (e.g. 0010,0800)
+- `swapBlueGreen`: Swap the blue and green color. RBG instead of RGB ("1" = true)
+- `use24hFormat`: Use the 24h format ("1" = true)
+- `ldrPin`: Define which GPIO pin the LDR is connected to (default = 35)
+- `timeZone`: Set time zone name to be used
+- `ntpServer`: Define URL of NTP server to be used
+- `canvasFile`: Name of the canvas file that should be used (e.g. my-theme.json)
+- `canvasServer`: URL of the server where the canvas file is saved
+- `manualPosix`: Avoid remote lookups of ezTime, by providing a posix string
+
+So for example if you want to set the brightness to 80 and your device has the IP 192.168.0.42, the easiest way to set the display brightness would be to cURL your device like this:
+```
+curl -X POST http://192.168.0.42/set?displayBright=80
+```
+
+**Be advised** 
+
+Right now you can only update a single attribute within a single request and afterwards your device needs to be restarted!

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,209 @@
+openapi: 3.0.3
+servers:
+    - url: "http://<clockwise-device>" # add IP address of your Clockwise device
+info:
+    title: Clockwise API
+    description: Clockwise API
+    version: 1.0.0
+paths:
+    /:
+        get:
+            description: Getting the settings page
+            responses:
+                "200":
+                    description: OK
+    /get:
+        get:
+            description: Getting all information
+            responses:
+                "204":
+                    description: No Content
+                    headers:
+                        X-displayBright:
+                            schema:
+                                type: integer
+                                example: 33
+                                minimum: 0
+                                maximum: 255
+                        X-autoBrightMin:
+                            schema:
+                                type: integer
+                                example: 1
+                                minimum: 0
+                                maximum: 4095
+                        X-autoBrightMax:
+                            schema:
+                                type: integer
+                                example: 230
+                                minimum: 0
+                                maximum: 4095
+                        X-swapBlueGreen:
+                            schema:
+                                type: integer
+                                example: 1
+                        X-use24hFormat:
+                            schema:
+                                type: integer
+                                example: 1
+                        X-ldrPin:
+                            schema:
+                                type: integer
+                                example: 35
+                        X-timeZone:
+                            schema:
+                                type: string
+                                example: Europe/Paris
+                        X-wifiSsid:
+                            schema:
+                                type: string
+                                example: MyWifi
+                        X-ntpServer:
+                            schema:
+                                type: string
+                                example: de.pool.ntp.org
+                        X-canvasFile:
+                            schema:
+                                type: string
+                                example: my-theme.json
+                        X-canvasServer:
+                            schema:
+                                type: string
+                                example: raw.githubusercontent.com
+                        X-CW_FW_VERSION:
+                            schema:
+                                type: string
+                                example: 1.4.0
+                        X-CW_FW_NAME:
+                            schema:
+                                type: string
+                                example: CW_20230701
+                        X-CLOCKFACE_NAME:
+                            schema:
+                                type: string
+                                example: UNKNOWN
+    /read:
+        get:
+            description: Getting pin information
+            parameters:
+                - name: pin
+                  in: query
+                  description: Get pin value
+                  required: false
+                  schema:
+                      type: integer
+                      format: int64
+            responses:
+                "204":
+                    description: No Content
+    /restart:
+        post:
+            description: Restart device
+            responses:
+                "204":
+                    description: No Content
+    /set:
+        post:
+            parameters:
+                - name: displayBright
+                  in: query
+                  description: Number to set the display brightness to
+                  required: false
+                  schema:
+                      type: integer
+                      default: 32
+                      minimum: 0
+                      maximum: 255
+                - name: wifiSsid
+                  in: query
+                  required: false
+                  description: SSID of wifi network to be used
+                  schema:
+                      type: string
+                - name: wifiPwd
+                  in: query
+                  required: false
+                  description: Wifi password to be used
+                  schema:
+                      type: string
+                - name: autoBright
+                  in: query
+                  required: false
+                  description: |
+                    Set min and max values for autoBrightness. The value is a 
+                    compound string that houses both values in one. First 
+                    part is min, second part is max. 
+
+                    If current brightness value is smaller than minimum 
+                    brightness the device will turn off.
+                  schema:
+                      type: string
+                      pattern: ^\d{4},\d{4}$
+                      default: 0000,0800
+                - name: swapBlueGreen
+                  in: query
+                  required: false
+                  description: |
+                    Swap the blue and green color. Basically use RBG instead of 
+                    RGB.
+                  schema:
+                      type: number
+                      enum:
+                        - 0
+                        - 1
+                - name: use24hFormat
+                  in: query
+                  required: false
+                  description: |
+                    Defines if the 24h format should be used
+                  schema:
+                      type: integer
+                      enum:
+                        - 0
+                        - 1
+                - name: ldrPin
+                  in: query
+                  required: false
+                  description: Define which GPIO pin the LDR is connected to
+                  schema:
+                      type: integer
+                      default: 35
+                - name: timeZone
+                  in: query
+                  required: false
+                  description: Set the time zone that should be used
+                  schema:
+                      type: string
+                      default: "America/Sao_Paulo"
+                - name: ntpServer
+                  in: query
+                  required: false
+                  description: |
+                    Define URL of NTP server to be used for synchronization
+                  schema:
+                      type: string
+                      default: "time.google.com"
+                - name: canvasFile
+                  in: query
+                  required: false
+                  description: |
+                    Name of the canvas file that should be used (e.g. 
+                    `my-theme.json`)
+                  schema:
+                      type: string
+                - name: canvasServer
+                  in: query
+                  required: false
+                  description: URL of the server where the canvas file is saved
+                  schema:
+                      type: string
+                      default: "raw.githubusercontent.com"
+                - name: manualPosix
+                  in: query
+                  required: false
+                  description: |
+                    Avoid remote lookups of ezTime, by providing a posix string
+                  schema:
+                      type: string
+            responses:
+                "204":
+                    description: No Content

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -20,64 +20,78 @@ paths:
                     description: No Content
                     headers:
                         X-displayBright:
+                            description: Display brightness
                             schema:
                                 type: integer
                                 example: 33
                                 minimum: 0
                                 maximum: 255
                         X-autoBrightMin:
+                            description: Auto brightness minimum
                             schema:
                                 type: integer
                                 example: 1
                                 minimum: 0
                                 maximum: 4095
                         X-autoBrightMax:
+                            description: Auto brightness maximum
                             schema:
                                 type: integer
                                 example: 230
                                 minimum: 0
                                 maximum: 4095
                         X-swapBlueGreen:
+                            description: Is RBG used instead of RGB (blue & green are switched)?
                             schema:
                                 type: integer
                                 example: 1
                         X-use24hFormat:
+                            description: Use the 24h format instead of 12h for the clock
                             schema:
                                 type: integer
                                 example: 1
                         X-ldrPin:
+                            description: Which GPIO pin is currently defined for the LDR
                             schema:
                                 type: integer
                                 example: 35
                         X-timeZone:
+                            description: Currently selected time zone
                             schema:
                                 type: string
                                 example: Europe/Paris
                         X-wifiSsid:
+                            description: SSID the device is connected to
                             schema:
                                 type: string
                                 example: MyWifi
                         X-ntpServer:
+                            description: URL of the NTP server the device is connected to
                             schema:
                                 type: string
                                 example: de.pool.ntp.org
                         X-canvasFile:
+                            description: Name of the canvas file that is currently being used
                             schema:
                                 type: string
                                 example: my-theme.json
                         X-canvasServer:
+                            description: Address of the canvas server that is currently being used
                             schema:
                                 type: string
                                 example: raw.githubusercontent.com
                         X-CW_FW_VERSION:
+                            description: Clockwise firmware version
                             schema:
                                 type: string
                                 example: 1.4.0
                         X-CW_FW_NAME:
+                            description: Clockwise firmware name
                             schema:
                                 type: string
                                 example: CW_20230701
                         X-CLOCKFACE_NAME:
+                            description: Clockface name (e.g. `cw-cf-0x01`)
                             schema:
                                 type: string
                                 example: UNKNOWN

--- a/index.md
+++ b/index.md
@@ -58,6 +58,10 @@ Here in this section you can upload the desired clockface to your device. A step
 You will need only three components to make a Clockwise device, they are easily found on stores like Amazon and Aliexpress. More details [here](https://github.com/jnthas/clockwise/tree/main#driving-the-led-matrix).
 
 
+## API
+Clockwise comes with a small built in server that provides a few calls to control your device.
+
+Have a look at our dedicated [API documentation](/docs/api)
 ## About
 
 Clockwise was an idea I had while working with 64x64 LED matrices. These displays are about the size of a wall clock and with the ESP32, besides controlling the content presented on the display we also gain the functionality of WiFi, Bluetooth, touch buttons and other sensors, which gives us basically a smart wall clock. I wrote a post for [instructables](https://www.instructables.com/Mario-Bros-Clock/).


### PR DESCRIPTION
This PR adds a separate API documentation site that should give an overview of the currently offered API calls. For easier testing and access an OpenAPI specification file (openapi.yml) is being provided that can be used with your favorite tools to call the API.

Fixes #40 