### PR TITLE
Optimize automatic brightness and NTP synchronization

### DIFF
--- a/firmware/lib/cw-commons/CWDateTime.cpp
+++ b/firmware/lib/cw-commons/CWDateTime.cpp
@@ -16,7 +16,7 @@ void CWDateTime::begin(const char *timeZone, bool use24format, const char *ntpSe
 
   this->use24hFormat = use24format;
   ezt::updateNTP();
-  waitForSync();
+  waitForSync(10);
 }
 
 String CWDateTime::getFormattedTime()

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -67,11 +67,11 @@ void automaticBrightControl()
       uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, slots);
       uint8_t mapBright = map(mapLDR, 1, slots, minBright, maxBright);
 
-      Serial.printf("LDR: %d, mapLDR: %d, Bright: %d\n", currentValue, mapLDR, mapBright);
+      // Serial.printf("LDR: %d, mapLDR: %d, Bright: %d\n", currentValue, mapLDR, mapBright);
       if(abs(currentBrightSlot - mapLDR ) >= 2 || mapBright == 0){
            dma_display->setBrightness8(mapBright);
            currentBrightSlot=mapLDR;
-           Serial.printf("setBrightness: %d , Update currentBrightSlot to %d\n", mapBright, mapLDR);
+          //  Serial.printf("setBrightness: %d , Update currentBrightSlot to %d\n", mapBright, mapLDR);
       }
       autoBrightMillis = millis();
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -64,7 +64,7 @@ void automaticBrightControl()
       uint8_t maxBright = ClockwiseParams::getInstance()->displayBright;
 
       uint8_t slots = 10; //10 slots
-      uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, slots);
+      uint8_t mapLDR = map(currentValue > ldrMax ? ldrMax : currentValue, ldrMin, ldrMax, 1, slots);
       uint8_t mapBright = map(mapLDR, 1, slots, minBright, maxBright);
 
       // Serial.printf("LDR: %d, mapLDR: %d, Bright: %d\n", currentValue, mapLDR, mapBright);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -24,6 +24,7 @@ CWDateTime cwDateTime;
 
 bool autoBrightEnabled;
 long autoBrightMillis = 0;
+uint8_t currentBrightSlot = -1;
 
 void displaySetup(bool swapBlueGreen, uint8_t displayBright, uint8_t displayRotation)
 {
@@ -62,13 +63,16 @@ void automaticBrightControl()
       const uint8_t minBright = (currentValue < ldrMin ? MIN_BRIGHT_DISPLAY_OFF : MIN_BRIGHT_DISPLAY_ON);
       uint8_t maxBright = ClockwiseParams::getInstance()->displayBright;
 
-      uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, 5);  //5 slots
-      uint8_t mapBright = map(mapLDR, 1, 5, minBright, maxBright);
+      uint8_t slots = 10; //10 slots
+      uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, slots);
+      uint8_t mapBright = map(mapLDR, 1, slots, minBright, maxBright);
 
-      //Serial.printf("LDR: %d, Bright: %d\n", currentValue, mapBright);
-
-      dma_display->setBrightness8(mapBright);
-
+      Serial.printf("LDR: %d, mapLDR: %d, Bright: %d\n", currentValue, mapLDR, mapBright);
+      if(abs(currentBrightSlot - mapLDR ) >= 2 || mapBright == 0){
+           dma_display->setBrightness8(mapBright);
+           currentBrightSlot=mapLDR;
+           Serial.printf("setBrightness: %d , Update currentBrightSlot to %d\n", mapBright, mapLDR);
+      }
       autoBrightMillis = millis();
     }
   }


### PR DESCRIPTION
Thanks jnthas, I like this project very much and made some optimizations.

Two optimizations:
1.In the original auto-brightness code, the LDR reading value is first mapped to slot 1-5 ,then map slot 1-5 to screen brightness value and set.
`uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, 5);`
 `uint8_t mapBright = map(mapLDR, 1, 5, minBright, maxBright);`
 `dma_display->setBrightness8(mapBright);`
The issue is that currentValue is a analog value and has certain fluctuations, for example, I used GL5539 ldr and a 10K voltage dividing resistor , in my room, when the brightness remains unchanged, the currentValue fluctuates between 1800-2000，
`uint8_t mapLDR = map(currentValue, ldrMin, ldrMax, 1, 5);`
the mapLDR might get slot 3 or 4 , so next line mapBright might get two bright value ,in this case the critical value is read, the brightness of the LED will dim or brighten every 3 seconds, between two adjacent slots.

I increased the slots to 10 and added the current slot:
`uint8_t currentBrightSlot`
Only when the difference of slots is greater than or equal to 2 , the LED brightness will be changed, to avoid frequent brightness adjustments caused by fluctuations in LDR analog values.
and this line:
`uint8_t mapLDR = map(currentValue > ldrMax ? ldrMax : currentValue, ldrMin, ldrMax, 1, slots);`
currentValue and ldrMax are compared to prevent the result slots larger than 10.
and this line:
`if(abs(currentBrightSlot - mapLDR ) >= 2 || mapBright == 0){`
mapBright == 0 
This is to prevent the environment from dimming when the current slot is 2 and you get slot 1, but the screen cannot be adjusted to black because abs(currentBrightSlot - mapLDR ) == 1.

2.The clock will be stuck in the NTP synchronization screen when starting up, if the NTP server address settings are wrong, or the server cannot provide services, at this time, the clock cannot provide web services, and the ntp server address cannot be re-config through the web page.
In firmware/lib/cw-commons/CWDateTime.cpp
`waitForSync(10);`
I set the NTP synchronization timeout to 10 seconds. When the NTP time cannot be synchronized within 10 seconds, waitForSync(10); returns directly without blocking. At this time, although the clock time starts from 1970-1-1 8:00,  You can still open the web page to re-config the NTP server address.

![IMG_20240422_215528](https://github.com/jnthas/clockwise/assets/48149654/52f2fde4-3bd1-446d-8053-d1ff8d9af5c5)

https://www.youtube.com/watch?v=9vXFssfQ6p4
