### PR TITLE
Support 2 chained/stacked 64x32 DMD Led Panels

### DIFF
--- a/firmware/lib/cw-commons/CWPreferences.h
+++ b/firmware/lib/cw-commons/CWPreferences.h
@@ -13,6 +13,7 @@ struct ClockwiseParams
 
     const char* const PREF_SWAP_BLUE_GREEN = "swapBlueGreen";
     const char* const PREF_USE_24H_FORMAT = "use24hFormat";
+    const char* const CHAIN = "chain";
     const char* const PREF_DISPLAY_BRIGHT = "displayBright";
     const char* const PREF_DISPLAY_ABC_MIN = "autoBrightMin";
     const char* const PREF_DISPLAY_ABC_MAX = "autoBrightMax";
@@ -28,6 +29,7 @@ struct ClockwiseParams
 
     bool swapBlueGreen;
     bool use24hFormat;
+    bool chain;
     uint8_t displayBright;
     uint16_t autoBrightMin;
     uint16_t autoBrightMax;
@@ -57,6 +59,7 @@ struct ClockwiseParams
     {
         preferences.putBool(PREF_SWAP_BLUE_GREEN, swapBlueGreen);
         preferences.putBool(PREF_USE_24H_FORMAT, use24hFormat);
+        preferences.putBool(CHAIN, chain);
         preferences.putUInt(PREF_DISPLAY_BRIGHT, displayBright);
         preferences.putUInt(PREF_DISPLAY_ABC_MIN, autoBrightMin);
         preferences.putUInt(PREF_DISPLAY_ABC_MAX, autoBrightMax);
@@ -75,6 +78,7 @@ struct ClockwiseParams
     {
         swapBlueGreen = preferences.getBool(PREF_SWAP_BLUE_GREEN, false);
         use24hFormat = preferences.getBool(PREF_USE_24H_FORMAT, true);
+        chain = preferences.getBool(CHAIN, false);
         displayBright = preferences.getUInt(PREF_DISPLAY_BRIGHT, 32);
         autoBrightMin = preferences.getUInt(PREF_DISPLAY_ABC_MIN, 0);
         autoBrightMax = preferences.getUInt(PREF_DISPLAY_ABC_MAX, 0);

--- a/firmware/lib/cw-commons/CWWebServer.h
+++ b/firmware/lib/cw-commons/CWWebServer.h
@@ -17,8 +17,8 @@ struct ClockwiseWebServer
   bool force_restart;
   const char* HEADER_TEMPLATE_D = "X-%s: %d\r\n";
   const char* HEADER_TEMPLATE_S = "X-%s: %s\r\n";
- 
-  static ClockwiseWebServer *getInstance()
+
+  static ClockwiseWebServer *getInstance() 
   {
     static ClockwiseWebServer base;
     return &base;
@@ -39,7 +39,6 @@ struct ClockwiseWebServer
   {
     if (force_restart)
       StatusController::getInstance()->forceRestart();
-
 
     WiFiClient client = server.available();
     if (client)
@@ -83,49 +82,88 @@ struct ClockwiseWebServer
 
   void processRequest(WiFiClient client, String method, String path, String key, String value)
   {
-    if (method == "GET" && path == "/") {
+    if (method == "GET" && path == "/")
+    {
       client.println("HTTP/1.0 200 OK");
       client.println("Content-Type: text/html");
       client.println();
       client.println(SETTINGS_PAGE);
-    } else if (method == "GET" && path == "/get") {
+    }
+    else if (method == "GET" && path == "/get")
+    {
       getCurrentSettings(client);
-    } else if (method == "GET" && path == "/read") {
-      if (key == "pin") {
+    }
+    else if (method == "GET" && path == "/read")
+    {
+      if (key == "pin")
+      {
         readPin(client, key, value.toInt());
       }
-    } else if (method == "POST" && path == "/restart") {
+    }
+    else if (method == "POST" && path == "/restart")
+    {
       client.println("HTTP/1.0 204 No Content");
       force_restart = true;
-    } else if (method == "POST" && path == "/set") {
+    }
+    else if (method == "POST" && path == "/set")
+    {
       ClockwiseParams::getInstance()->load();
-      //a baby seal has died due this ifs
-      if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_BRIGHT) {
+      // a baby seal has died due this ifs
+      if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_BRIGHT)
+      {
         ClockwiseParams::getInstance()->displayBright = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_WIFI_SSID) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_WIFI_SSID)
+      {
         ClockwiseParams::getInstance()->wifiSsid = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_WIFI_PASSWORD) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_WIFI_PASSWORD)
+      {
         ClockwiseParams::getInstance()->wifiPwd = value;
-      } else if (key == "autoBright") {   //autoBright=0010,0800
-        ClockwiseParams::getInstance()->autoBrightMin = value.substring(0,4).toInt();
-        ClockwiseParams::getInstance()->autoBrightMax = value.substring(5,9).toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_SWAP_BLUE_GREEN) {
+      }
+      else if (key == "autoBright")
+      { // autoBright=0010,0800
+        ClockwiseParams::getInstance()->autoBrightMin = value.substring(0, 4).toInt();
+        ClockwiseParams::getInstance()->autoBrightMax = value.substring(5, 9).toInt();
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_SWAP_BLUE_GREEN)
+      {
         ClockwiseParams::getInstance()->swapBlueGreen = (value == "1");
-      } else if (key == ClockwiseParams::getInstance()->PREF_USE_24H_FORMAT) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_USE_24H_FORMAT)
+      {
         ClockwiseParams::getInstance()->use24hFormat = (value == "1");
-      } else if (key == ClockwiseParams::getInstance()->PREF_LDR_PIN) {
+      }
+      else if (key == ClockwiseParams::getInstance()->CHAIN)
+      {
+        ClockwiseParams::getInstance()->chain = (value == "1");
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_LDR_PIN)
+      {
         ClockwiseParams::getInstance()->ldrPin = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_TIME_ZONE) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_TIME_ZONE)
+      {
         ClockwiseParams::getInstance()->timeZone = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_NTP_SERVER) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_NTP_SERVER)
+      {
         ClockwiseParams::getInstance()->ntpServer = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_FILE) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_FILE)
+      {
         ClockwiseParams::getInstance()->canvasFile = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_SERVER) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_SERVER)
+      {
         ClockwiseParams::getInstance()->canvasServer = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_MANUAL_POSIX) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_MANUAL_POSIX)
+      {
         ClockwiseParams::getInstance()->manualPosix = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_ROTATION) {
+      }
+      else if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_ROTATION)
+      {
         ClockwiseParams::getInstance()->displayRotation = value.toInt();
       }
       ClockwiseParams::getInstance()->save();
@@ -133,19 +171,18 @@ struct ClockwiseWebServer
     }
   }
 
-
-
-  void readPin(WiFiClient client, String key, uint16_t pin) {
+  void readPin(WiFiClient client, String key, uint16_t pin)
+  {
     ClockwiseParams::getInstance()->load();
 
     client.println("HTTP/1.0 204 No Content");
     client.printf(HEADER_TEMPLATE_D, key, analogRead(pin));
-    
+
     client.println();
   }
 
-
-  void getCurrentSettings(WiFiClient client) {
+  void getCurrentSettings(WiFiClient client)
+  {
     ClockwiseParams::getInstance()->load();
 
     client.println("HTTP/1.0 204 No Content");
@@ -155,7 +192,8 @@ struct ClockwiseWebServer
     client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->PREF_DISPLAY_ABC_MAX, ClockwiseParams::getInstance()->autoBrightMax);
     client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->PREF_SWAP_BLUE_GREEN, ClockwiseParams::getInstance()->swapBlueGreen);
     client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->PREF_USE_24H_FORMAT, ClockwiseParams::getInstance()->use24hFormat);
-    client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->PREF_LDR_PIN, ClockwiseParams::getInstance()->ldrPin);    
+    client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->CHAIN, ClockwiseParams::getInstance()->chain);
+    client.printf(HEADER_TEMPLATE_D, ClockwiseParams::getInstance()->PREF_LDR_PIN, ClockwiseParams::getInstance()->ldrPin);
     client.printf(HEADER_TEMPLATE_S, ClockwiseParams::getInstance()->PREF_TIME_ZONE, ClockwiseParams::getInstance()->timeZone.c_str());
     client.printf(HEADER_TEMPLATE_S, ClockwiseParams::getInstance()->PREF_WIFI_SSID, ClockwiseParams::getInstance()->wifiSsid.c_str());
     client.printf(HEADER_TEMPLATE_S, ClockwiseParams::getInstance()->PREF_NTP_SERVER, ClockwiseParams::getInstance()->ntpServer.c_str());
@@ -169,5 +207,4 @@ struct ClockwiseWebServer
     client.printf(HEADER_TEMPLATE_S, "CLOCKFACE_NAME", CLOCKFACE_NAME);
     client.println();
   }
-  
 };

--- a/firmware/lib/cw-commons/CWWebServer.h
+++ b/firmware/lib/cw-commons/CWWebServer.h
@@ -18,7 +18,7 @@ struct ClockwiseWebServer
   const char* HEADER_TEMPLATE_D = "X-%s: %d\r\n";
   const char* HEADER_TEMPLATE_S = "X-%s: %s\r\n";
 
-  static ClockwiseWebServer *getInstance() 
+  static ClockwiseWebServer *getInstance()
   {
     static ClockwiseWebServer base;
     return &base;

--- a/firmware/lib/cw-commons/SettingsWebPage.h
+++ b/firmware/lib/cw-commons/SettingsWebPage.h
@@ -70,6 +70,14 @@ const char SETTINGS_PAGE[] PROGMEM = R""""(
           property: "use24hFormat"
         },
         {
+          title: "Chain 64x32 panels",
+          description: "Use two 64x32 LED Panels instead of one single 64x64",
+          formInput: "<input class='w3-check' type='checkbox' id='chain' " + (settings.chain == '1' ? "checked" : "") + "><label for='chain'> Yep</label>",
+          icon: "fa-clock-o",
+          save: "updatePreference('chain', Number(chain.checked))",
+          property: "chain"
+        },
+        {
           title: "Swap Blue/Green pins?",
           description: "Swap Blue and Green pins because the panel is RBG instead of RGB",
           formInput: "<input class='w3-check' type='checkbox' id='swapBG' " + (settings.swapbluegreen == '1' ? "checked" : "") + "><label for='swapBG'> Yep</label>",
@@ -229,7 +237,7 @@ const char SETTINGS_PAGE[] PROGMEM = R""""(
     }
 
     //Local
-    //createCards({ "displayBright": 30, "swapBlueGreen": 1, "use24hFormat": 0, "timeZone": "Europe/Lisbon", "ntpServer": "pool.ntp.org", "wifiSsid": "test", "autoBrightMin":0, "autoBrightMax":800, "ldrPin":35, "cw_fw_version":"1.2.2", "clockface_name":"cw-cf-0x07", "canvasServer":"raw.githubusercontent.com", "canvasFile":"star-wars.json" });
+    //createCards({ "displayBright": 30, "swapBlueGreen": 1, "use24hFormat": 0, , "chain" : 0, "timeZone": "Europe/Lisbon", "ntpServer": "pool.ntp.org", "wifiSsid": "test", "autoBrightMin":0, "autoBrightMax":800, "ldrPin":35, "cw_fw_version":"1.2.2", "clockface_name":"cw-cf-0x07", "canvasServer":"raw.githubusercontent.com", "canvasFile":"star-wars.json" });
 
     //Embedded
     begin();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -15,17 +15,19 @@
 
 #define ESP32_LED_BUILTIN 2
 
-#define CHAINED_PANEL_RES_X 64 // Number of pixels wide of each INDIVIDUAL panel module. 
-#define CHAINED_PANEL_RES_Y 32 // Number of pixels tall of each INDIVIDUAL panel module.
-#define CHAINED_NUM_ROWS 2 // Number of rows of chained INDIVIDUAL PANELS
-#define CHAINED_NUM_COLS 1 // Number of rows of chained INDIVIDUAL PANELS
+// Single 64x64 LED panel use case
+#define PANEL_RES_X 64
+#define PANEL_RES_Y 64
+#define NUM_COLS 1
+#define NUM_ROWS 1
 
-#define PANEL_RES_X 64 // Number of pixels wide of each INDIVIDUAL panel module. 
-#define PANEL_RES_Y 64 // Number of pixels tall of each INDIVIDUAL panel module.
-#define NUM_COLS 1 // Number of INDIVIDUAL PANELS per ROW
-#define NUM_ROWS 1 // Number of rows of chained INDIVIDUAL PANELS
+// Chained 64x32 panels use case
+// #define CHAINED_PANEL_RES_X 64
+#define CHAINED_PANEL_RES_Y 32
+#define CHAINED_NUM_ROWS 2
+// #define CHAINED_NUM_COLS 1
 
-#define VIRTUAL_MATRIX_CHAIN_TYPE CHAIN_BOTTOM_LEFT_UP 
+#define VIRTUAL_MATRIX_CHAIN_TYPE CHAIN_BOTTOM_LEFT_UP
 
 MatrixPanel_I2S_DMA *dma_display = nullptr;
 VirtualMatrixPanel  *virtualDisp = nullptr;
@@ -42,10 +44,10 @@ uint8_t currentBrightSlot = -1;
 void displaySetup(bool swapBlueGreen, uint8_t displayBright, uint8_t displayRotation)
 {
   HUB75_I2S_CFG mxconfig(
-    ClockwiseParams::getInstance()->chain ? CHAINED_PANEL_RES_X : PANEL_RES_X,   // module width
-    ClockwiseParams::getInstance()->chain ? CHAINED_PANEL_RES_Y : PANEL_RES_Y,   // module height
-    ClockwiseParams::getInstance()->chain ? (CHAINED_PANEL_RES_X * CHAINED_PANEL_RES_Y) : (NUM_ROWS * NUM_COLS)    // chain length
-);
+    PANEL_RES_X,
+    ClockwiseParams::getInstance()->chain ? CHAINED_PANEL_RES_Y : PANEL_RES_Y,
+    ClockwiseParams::getInstance()->chain ? (CHAINED_NUM_ROWS * NUM_COLS) : (NUM_ROWS * NUM_COLS)
+  );
 
   if (swapBlueGreen)
   {


### PR DESCRIPTION
> [!NOTE]
> This is a work in progress, do not review yet 

After my frustration for not being capable of using my 64x32 panel to build this amazing clock, I decided to give it a try and make the option to chain this panels configurable.

I followed the instructions in [Can I chain Panels?](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA?tab=readme-ov-file#can-i-chain-panels) from [ESP32-HUB75-MatrixPanel-DMA](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA) I quickly noticed the following statement:

> Finally, if you wanted to chain 4 x (64x32px) panels to make 128x64px display (essentially a 2x2 grid of 64x32 LED Matrix modules), a little more magic will be required. Refer to the [VirtualMatrixPanel](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/blob/master/examples/VirtualMatrixPanel) example and the [AuroraDemo](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/blob/master/examples/AuroraDemo) example of its practical use.

Basically... if you need more than 1 row of panels, you should use VirtualMatrixPanel which I guess that could handle also the original use case of 64x64 panels even though is not strictly needed.

I need to test this in a single 64x64 panel since I don't have those (give it a go please @jnthas) but I think that it should work.

Added a setting section too to make this easily configurable

![imagen](https://github.com/user-attachments/assets/da6a571a-74ef-49e3-9499-19c8c6a9c58c)

Apologies for the diff changes about format in `firmware/lib/cw-commons/CWWebServer.h`, those were made automatically by my VSCode, I can revert those if requested
 