### PR TITLE
AP mode not working if SSID empty

### DIFF
--- a/firmware/lib/cw-commons/WiFiController.h
+++ b/firmware/lib/cw-commons/WiFiController.h
@@ -93,10 +93,10 @@ struct WiFiController
         Serial.printf("[WiFi] Connected to %s, IP address %s\n", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
         return true;
       }
+    }      
 
-      StatusController::getInstance()->wifiConnectionFailed("Setup WiFi via AP");
-      alternativeSetupMethod();
-    }
+    StatusController::getInstance()->wifiConnectionFailed("Setup WiFi via AP");
+    alternativeSetupMethod();
 
     StatusController::getInstance()->wifiConnectionFailed("WiFi Failed");
     return false;


### PR DESCRIPTION
Fix for not starting AP if SSID empty (e.g. flashing from platformio to new esp32)