### PR TITLE
Update esp-web-tools from 8.0.3 to the floating 10 tag

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -8,7 +8,7 @@
 
 <script
   type="module"
-  src="https://unpkg.com/esp-web-tools@8.0.3/dist/web/install-button.js?module">
+  src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module">
 </script>
 
 


### PR DESCRIPTION
The installer on clockwise.page loads `esp-web-tools@8.0.3` via `_includes/head-custom.html`. This switches it to the floating `@10` tag so the page follows the current major (10.4.0 today) and picks up patch releases automatically.

Since v8 the flashing stack was rebuilt on esptool-js, which is what brought support for the newer ESP32 variants (C2/C5/C6/C61/H2/P4). The Improv Wi-Fi flow was reworked in [10.3.0](https://github.com/esphome/esp-web-tools/releases/tag/10.3.0): the network picker keeps scanning while the form is shown and merges results, each network shows signal strength, RSSI and whether it is secured, the strongest one is preselected, a device reporting the Improv *stopped* state now says so instead of showing a form that cannot succeed, and Firefox is recognized as a supported WebSerial browser. [10.4.0](https://github.com/esphome/esp-web-tools/releases/tag/10.4.0) fixes a scan race and default-selection bug in that picker.

Since this is a jump across two majors, worth flashing one board from the page before merging.